### PR TITLE
Add COVID-19 Cases Summary Command

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -9,6 +9,7 @@ from modules import jesus
 from modules import random_cat_fact
 from modules import draw_card
 from modules import wiki_summary
+from modules import covid19
 
 class Actuator:
     """ Class object for handling command activations. """
@@ -31,7 +32,9 @@ class Actuator:
             "!jesus": self.jesus,
             "!catfact": self.cat_fact,
             "!draw": self.draw_card,
-            "!help": self.help
+            "!help": self.help,
+            "!covidglobal": self.covidglobal,
+            "!covidcountry": self.covidcountry
         }
 
     def command(self, msg, nick, pm):
@@ -125,6 +128,13 @@ class Actuator:
 
     def draw_card(self, argument):
         return draw_card.draw_card()
+
+    def covidglobal(self, argument):
+        return covid19.get_global_covid_cases()
+
+    def covidcountry(self, argument):
+        if (argument): return covid19.get_covid_cases_by_country(argument)
+        return self.missing_argument()
 
     def help(self, argument):
         return "The available commands are: " + str(list(self.dic))[1:-1]

--- a/modules/covid19.py
+++ b/modules/covid19.py
@@ -1,0 +1,59 @@
+import requests
+import json
+import re
+
+API_URL = 'https://api.covid19api.com/summary'
+
+def get_covid_cases_by_country(country):
+    try:
+        response = requests.get(API_URL)
+        response_json = json.loads(response.text)
+
+        if response_json['Message'] == 'Caching in progress':
+            return 'API Caching in progress, please try again later.'
+
+        country_data = next((data for data in response_json['Countries'] if data['Country'].lower() == country.lower()), {})
+
+        if country_data:
+            covid_info = '\
+                COVID-19 Cases for {Country} ({CountryCode}) - New Confirmed Cases: {NewConfirmed}, \
+                    Total Confirmed Cases: {TotalConfirmed}, \
+                        New Deaths: {NewDeaths}, \
+                            Total Deaths: {TotalDeaths}, \
+                                New Recovered Cases: {NewRecovered}, \
+                                    Total Recovered Cases: {TotalRecovered}'
+                
+
+            return re.sub(r"\s\s+" , " ", covid_info.format(**country_data))
+
+        else:
+            return 'Invalid Country Name'
+
+    except Exception as e:
+        print(e)
+        return 'Error Fetching COVID-19 Data'
+
+
+def get_global_covid_cases():
+    try:
+        response = requests.get(API_URL)
+        response_json = json.loads(response.text)
+
+        if response_json['Message'] == 'Caching in progress':
+            return 'API Caching in progress, please try again later.'
+
+        global_data = response_json['Global']
+
+        global_covid_info = '\
+            Global COVID-19 Cases - New Confirmed Cases: {NewConfirmed}, \
+                Total Confirmed Cases: {TotalConfirmed}, \
+                    New Deaths: {NewDeaths}, \
+                        Total Deaths: {TotalDeaths}, \
+                            New Recovered Cases: {NewRecovered}, \
+                                Total Recovered Cases: {TotalRecovered}'
+
+        return re.sub(r"\s\s+" , " ", global_covid_info.format(**global_data))
+
+    except Exception as e:
+        print(e)
+        return 'Error Fetching COVID-19 Data'

--- a/modules/covid19.py
+++ b/modules/covid19.py
@@ -5,16 +5,21 @@ import re
 API_URL = 'https://api.covid19api.com/summary'
 
 def get_covid_cases_by_country(country):
+    """Gets the COVID-19 cases by the input country."""
     try:
         response = requests.get(API_URL)
         response_json = json.loads(response.text)
 
+        # The API undergoes caching periodically,
+        # during which it is unavailable.
         if response_json['Message'] == 'Caching in progress':
             return 'API Caching in progress, please try again later.'
 
+        # Search for the country in the summary response
         country_data = next((data for data in response_json['Countries'] if data['Country'].lower() == country.lower()), {})
 
         if country_data:
+            # Return the stats if the country is found
             covid_info = '\
                 COVID-19 Cases for {Country} ({CountryCode}) - New Confirmed Cases: {NewConfirmed}, \
                     Total Confirmed Cases: {TotalConfirmed}, \
@@ -23,7 +28,8 @@ def get_covid_cases_by_country(country):
                                 New Recovered Cases: {NewRecovered}, \
                                     Total Recovered Cases: {TotalRecovered}'
                 
-
+            # Remove any extra whitespace and fill the string
+            # with keys from the data dictionary
             return re.sub(r"\s\s+" , " ", covid_info.format(**country_data))
 
         else:
@@ -35,13 +41,17 @@ def get_covid_cases_by_country(country):
 
 
 def get_global_covid_cases():
+    """Gets the global COVID-19 Cases."""
     try:
         response = requests.get(API_URL)
         response_json = json.loads(response.text)
 
+        # The API undergoes caching periodically,
+        # during which it is unavailable.
         if response_json['Message'] == 'Caching in progress':
             return 'API Caching in progress, please try again later.'
 
+        # Retrieve and return the global COVID-19 cases
         global_data = response_json['Global']
 
         global_covid_info = '\
@@ -52,6 +62,8 @@ def get_global_covid_cases():
                             New Recovered Cases: {NewRecovered}, \
                                 Total Recovered Cases: {TotalRecovered}'
 
+        # Remove any extra whitespace and fill the string
+        # with keys from the data dictionary
         return re.sub(r"\s\s+" , " ", global_covid_info.format(**global_data))
 
     except Exception as e:

--- a/tests.txt
+++ b/tests.txt
@@ -18,3 +18,5 @@
 !catfact
 !draw
 !help
+!covidglobal
+!covidcountry India


### PR DESCRIPTION
I've added a COVID-19 summary module using the [CORONAVIRUS COVID19 API](https://covid19api.com/).

Two commands are added - !covidglobal and !covidcountry

!covidglobal provides the global cases summary, and !covidcountry takes a country name as an argument and provides the case summary for that country.

It might be a good idea to have a function which shows the list of countries, so maybe that can be a further enhancement!