### PR TITLE
Add Sentiment Analysis Command

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -10,6 +10,7 @@ from modules import random_cat_fact
 from modules import draw_card
 from modules import wiki_summary
 from modules import covid19
+from modules import sentiment
 
 class Actuator:
     """ Class object for handling command activations. """
@@ -34,7 +35,8 @@ class Actuator:
             "!draw": self.draw_card,
             "!help": self.help,
             "!covidglobal": self.covidglobal,
-            "!covidcountry": self.covidcountry
+            "!covidcountry": self.covidcountry,
+            "!sentiment": self.sentiment
         }
 
     def command(self, msg, nick, pm):
@@ -134,6 +136,10 @@ class Actuator:
 
     def covidcountry(self, argument):
         if (argument): return covid19.get_covid_cases_by_country(argument)
+        return self.missing_argument()
+
+    def sentiment(self, argument):
+        if (argument): return sentiment.get_sentiment(argument)
         return self.missing_argument()
 
     def help(self, argument):

--- a/commands.py
+++ b/commands.py
@@ -86,7 +86,7 @@ class Actuator:
         self.pm = bool
 
     def missing_argument(self):
-        return "Did you forget and argument?"
+        return "Did you forget an argument?"
 
     def urban(self, argument):
         if (argument): return urban_dictionary.urban_term(argument)

--- a/modules/sentiment.py
+++ b/modules/sentiment.py
@@ -1,0 +1,21 @@
+import requests
+import json
+
+def get_sentiment(sentence):
+
+    # Base URL for the sentiment analysis API
+    url = 'https://sentim-api.herokuapp.com/api/v1/'
+    
+    # Setting headers and body as specified by the API docs
+    headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+    body = {'text': sentence}
+
+    # Send the request and load the response into a dictionary
+    response = requests.post(url, data=json.dumps(body), headers=headers)
+    response_json = json.loads(response.text)
+
+    # Get the sentence type (positive / negative) and the polarity
+    sentence_type = response_json['result']['type']
+    sentence_polarity = response_json['result']['polarity']
+
+    return f'The sentence is {sentence_type} and its polarity is {sentence_polarity}'

--- a/tests.txt
+++ b/tests.txt
@@ -20,3 +20,4 @@
 !help
 !covidglobal
 !covidcountry India
+!sentiment

--- a/tests.txt
+++ b/tests.txt
@@ -20,4 +20,5 @@
 !help
 !covidglobal
 !covidcountry India
-!sentiment
+!sentiment this sentence is very nice
+!sentiment this is not a nice sentence at all


### PR DESCRIPTION
I've added a sentiment analysis command using the [SENTIM-API](https://sentim-api.herokuapp.com/).

Syntax:
`!sentiment sentence`

I've also fixed a small typo in the `missing_argument` function.

The API also supports multiple sentences as input, so maybe someone can enhance the current code to take in multiple sentences and call the API with it.