### PR TITLE
don't return 'command not found' whenever some msg starts with !

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -81,7 +81,9 @@ class Actuator:
 
         # Activate command
         def switcher(command, argument):
-            return self.dic.get(command)(argument)
+            if command in self.dic.keys():
+                return self.dic.get(command)(argument)
+
         try:
             result = switcher(command[0], (command[1]))
             return result


### PR DESCRIPTION
Previously the bot responded with "Sorry, I did not understand that command." whenever a message starting with "!" does not match a command. This is annoying and unnecessary. Don't know why I initially made it like this.